### PR TITLE
refactor(fq): 코드 품질 개선 — 안정성 수정, 재시도 로직, Javadoc, 테스트 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .claude
 CLAUDE.md
+.worktrees
 .idea
 .gradle
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.claude
+CLAUDE.md
 .idea
 .gradle
 build/

--- a/src/main/java/io/github/ppzxc/fq/FileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/FileQueue.java
@@ -2,25 +2,115 @@ package io.github.ppzxc.fq;
 
 import java.util.List;
 
+/**
+ * A persistent file-based FIFO queue that stores serializable objects.
+ *
+ * <p>Implementations are expected to be thread-safe and to persist data across
+ * process restarts using an underlying file storage engine.</p>
+ *
+ * @param <T> the type of elements held in this queue; must be serializable
+ */
 public interface FileQueue<T> {
 
+  /**
+   * Returns the absolute file path used for persistent storage.
+   *
+   * @return the file name (absolute path) of the underlying storage file
+   */
   String fileName();
 
+  /**
+   * Adds a single element to the tail of this queue.
+   *
+   * @param value the element to add; must not be {@code null}
+   * @return {@code true} if the element was successfully added
+   * @throws IllegalArgumentException if {@code value} is {@code null}
+   * @throws FileQueueException       if the queue is full (maxSize exceeded)
+   * @throws IllegalStateException    if the queue has been closed
+   */
   boolean enqueue(T value);
 
+  /**
+   * Adds all elements in the given list to the tail of this queue atomically.
+   *
+   * <p>All elements are validated before any are added. If the combined size
+   * would exceed maxSize, a {@link FileQueueException} is thrown and no elements
+   * are added.</p>
+   *
+   * @param value the list of elements to add; must not be {@code null} and must
+   *              not contain {@code null} elements
+   * @return {@code true} if all elements were successfully added, or {@code true}
+   *         if the list is empty
+   * @throws IllegalArgumentException if {@code value} is {@code null} or contains
+   *                                  a {@code null} element
+   * @throws FileQueueException       if adding all elements would exceed maxSize
+   * @throws IllegalStateException    if the queue has been closed
+   */
   boolean enqueue(List<T> value);
 
+  /**
+   * Removes and returns the element at the head of this queue.
+   *
+   * @return the head element, or {@code null} if the queue is empty
+   * @throws IllegalStateException if the queue has been closed
+   */
   T dequeue();
 
+  /**
+   * Removes and returns up to {@code size} elements from the head of this queue.
+   *
+   * <p>If fewer than {@code size} elements are available, all available elements
+   * are returned.</p>
+   *
+   * @param size the maximum number of elements to dequeue; must be &ge; 0
+   * @return a list of dequeued elements (may be empty, never {@code null})
+   * @throws IllegalArgumentException if {@code size} is negative
+   * @throws IllegalStateException    if the queue has been closed
+   */
   List<T> dequeue(int size);
 
+  /**
+   * Returns {@code true} if this queue contains no elements.
+   *
+   * @return {@code true} if the queue is empty
+   * @throws IllegalStateException if the queue has been closed
+   */
   boolean isEmpty();
 
+  /**
+   * Returns the number of elements currently in this queue.
+   *
+   * @return the current queue size (tail - head)
+   * @throws IllegalStateException if the queue has been closed
+   */
   long size();
 
+  /**
+   * Logs runtime metrics for this queue instance under the given name.
+   *
+   * <p>Logged fields include total operations, total commits, current size,
+   * head pointer, and tail pointer.</p>
+   *
+   * @param name a label used to identify this queue in the log output
+   */
   void metric(String name);
 
+  /**
+   * Flushes pending data and closes the underlying storage.
+   *
+   * <p>This method is idempotent; calling it multiple times has no additional effect.
+   * After closing, all mutating operations will throw {@link IllegalStateException}.</p>
+   */
   void close();
 
+  /**
+   * Compacts the underlying storage file if its size exceeds the configured threshold.
+   *
+   * <p>Compaction reclaims disk space by rewriting the storage file, removing
+   * obsolete data. If the file size is below the configured
+   * {@code compactByFileSize} threshold, this is a no-op (logged only).</p>
+   *
+   * @throws IllegalStateException if the queue has been closed
+   */
   void compactFile();
 }

--- a/src/main/java/io/github/ppzxc/fq/FileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/FileQueue.java
@@ -33,9 +33,9 @@ public interface FileQueue<T> {
   /**
    * Adds all elements in the given list to the tail of this queue atomically.
    *
-   * <p>All elements are validated before any are added. If the combined size
-   * would exceed maxSize, a {@link FileQueueException} is thrown and no elements
-   * are added.</p>
+   * <p>All elements are validated before any are added. If {@code currentSize + list.size > maxSize},
+   * a {@link FileQueueException} is thrown and no elements are added.
+   * Unlike single-element enqueue, a batch can fill the queue exactly to maxSize.</p>
    *
    * @param value the list of elements to add; must not be {@code null} and must
    *              not contain {@code null} elements

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -238,6 +238,9 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     for (int attempt = 0; attempt < properties.getMaxRetry(); attempt++) {
       lock.writeLock().lock();
       try {
+        if (closed) {
+          throw new IllegalStateException("[MVStoreFileQueue] Queue is already closed");
+        }
         return action.get();
       } catch (FileQueueException | IllegalArgumentException | IllegalStateException e) {
         throw e;
@@ -258,6 +261,9 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     for (int attempt = 0; attempt < properties.getMaxRetry(); attempt++) {
       lock.readLock().lock();
       try {
+        if (closed) {
+          throw new IllegalStateException("[MVStoreFileQueue] Queue is already closed");
+        }
         return action.get();
       } catch (FileQueueException | IllegalArgumentException | IllegalStateException e) {
         throw e;

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -90,7 +90,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     }
     return executeWithWriteLock(() -> {
       if (size() >= properties.getMaxSize()) {
-        throw new FileQueueException("[MVStoreFileQueue] Queue is full: " + size() + " > " + properties.getMaxSize());
+        throw new FileQueueException("[MVStoreFileQueue] Queue is full: size " + size() + " >= maxSize " + properties.getMaxSize());
       }
       try {
         long key = tail.getAndIncrement();
@@ -121,7 +121,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     }
     return executeWithWriteLock(() -> {
       if (size() + value.size() >= properties.getMaxSize()) {
-        throw new FileQueueException("Queue is full: " + size() + " > " + properties.getMaxSize());
+        throw new FileQueueException("[MVStoreFileQueue] Queue is full: size " + size() + " >= maxSize " + properties.getMaxSize());
       }
       value.forEach(v -> queue.put(tail.getAndIncrement(), v));
       commitIfNeeded();

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -239,6 +239,8 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       lock.writeLock().lock();
       try {
         return action.get();
+      } catch (FileQueueException | IllegalArgumentException | IllegalStateException e) {
+        throw e;
       } catch (Exception e) {
         log.info("[MVStoreFileQueue] Failed to execute with write lock: retry {}", attempt, e);
         exception = e;
@@ -257,6 +259,8 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       lock.readLock().lock();
       try {
         return action.get();
+      } catch (FileQueueException | IllegalArgumentException | IllegalStateException e) {
+        throw e;
       } catch (Exception e) {
         log.info("[MVStoreFileQueue] Failed to execute with read lock: retry {}", attempt, e);
         exception = e;

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -272,12 +272,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
   private void commitIfNeeded() {
     if (totalOperation.incrementAndGet() % properties.getBatchSize() == 0) {
       if (properties.isAutoCommitDisabled()) {
-        if (log.isDebugEnabled()) {
-          log.debug("total={} commits={} batch={} message=commit", totalOperation.get(),
-            totalCommits.get(), properties.getBatchSize());
-        }
-        mvStore.commit();
-        totalCommits.incrementAndGet();
+        doCommit();
       } else {
         if (log.isDebugEnabled()) {
           log.debug("total={} commits={} batch={} message=enabled auto commit",
@@ -286,6 +281,15 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
         }
       }
     }
+  }
+
+  private void doCommit() {
+    if (log.isDebugEnabled()) {
+      log.debug("total={} commits={} batch={} message=commit", totalOperation.get(),
+        totalCommits.get(), properties.getBatchSize());
+    }
+    mvStore.commit();
+    totalCommits.incrementAndGet();
   }
 
   @FunctionalInterface

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -64,7 +64,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       this.totalOperation = new AtomicLong();
       this.totalCommits = new AtomicLong();
 
-      acquireWriteLock(() -> {
+      executeWithWriteLock(() -> {
         this.head.set(queue.firstKey() != null ? queue.firstKey() : 0);
         this.tail.set(queue.lastKey() != null ? queue.lastKey() + 1 : 0);
         this.totalOperation.set(0);
@@ -88,7 +88,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     if (value == null) {
       throw new IllegalArgumentException("[MVStoreFileQueue] value cannot be null");
     }
-    return acquireWriteLock(() -> {
+    return executeWithWriteLock(() -> {
       if (size() >= properties.getMaxSize()) {
         throw new FileQueueException("[MVStoreFileQueue] Queue is full: " + size() + " > " + properties.getMaxSize());
       }
@@ -119,7 +119,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
         throw new IllegalArgumentException("[MVStoreFileQueue] value in list cannot be null");
       }
     }
-    return acquireWriteLock(() -> {
+    return executeWithWriteLock(() -> {
       if (size() + value.size() >= properties.getMaxSize()) {
         throw new FileQueueException("Queue is full: " + size() + " > " + properties.getMaxSize());
       }
@@ -132,7 +132,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
   @Override
   public T dequeue() {
     checkClosed();
-    return acquireWriteLock(() -> {
+    return executeWithWriteLock(() -> {
       if (isEmpty()) {
         return null;
       }
@@ -153,7 +153,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     if (size == 0) {
       return new ArrayList<>();
     }
-    return acquireWriteLock(() -> {
+    return executeWithWriteLock(() -> {
       List<T> dequeued = new ArrayList<>();
       for (int i = 0; i < size; i++) {
         if (isEmpty()) {
@@ -169,13 +169,13 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
   @Override
   public boolean isEmpty() {
     checkClosed();
-    return acquireReadLock(() -> head.get() == tail.get());
+    return executeWithReadLock(() -> head.get() == tail.get());
   }
 
   @Override
   public long size() {
     checkClosed();
-    return acquireReadLock(() -> tail.get() - head.get());
+    return executeWithReadLock(() -> tail.get() - head.get());
   }
 
   @Override
@@ -189,7 +189,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     if (closed) {
       return;
     }
-    acquireWriteLock(() -> {
+    executeWithWriteLock(() -> {
       if (closed) {
         return null;
       }
@@ -210,7 +210,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
   @Override
   public void compactFile() {
     checkClosed();
-    acquireWriteLock(() -> {
+    executeWithWriteLock(() -> {
       long before = fileSize();
       if (before > properties.getCompactByFileSize()) {
         long started = System.nanoTime();
@@ -233,14 +233,14 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     return var10000 + " " + abbreviate(unit);
   }
 
-  private <R> R acquireWriteLock(SupplierWithException<R, Exception> action) {
+  private <R> R executeWithWriteLock(SupplierWithException<R, Exception> action) {
     Exception exception = null;
     for (int attempt = 0; attempt < properties.getMaxRetry(); attempt++) {
       lock.writeLock().lock();
       try {
         return action.get();
       } catch (Exception e) {
-        log.info("[MVStoreFileQueue] Failed to acquire write lock: retry {}", attempt, e);
+        log.info("[MVStoreFileQueue] Failed to execute with write lock: retry {}", attempt, e);
         exception = e;
         sleepBackoff();
       } finally {
@@ -248,17 +248,17 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       }
     }
     throw new FileQueueException(
-      "[MVStoreFileQueue] Failed to acquire write lock after " + properties.getMaxRetry() + " attempts", exception);
+      "[MVStoreFileQueue] Failed to execute with write lock after " + properties.getMaxRetry() + " attempts", exception);
   }
 
-  private <R> R acquireReadLock(SupplierWithException<R, Exception> action) {
+  private <R> R executeWithReadLock(SupplierWithException<R, Exception> action) {
     Exception exception = null;
     for (int attempt = 0; attempt < properties.getMaxRetry(); attempt++) {
       lock.readLock().lock();
       try {
         return action.get();
       } catch (Exception e) {
-        log.info("Failed to acquire read lock: retry {}", attempt, e);
+        log.info("[MVStoreFileQueue] Failed to execute with read lock: retry {}", attempt, e);
         exception = e;
         sleepBackoff();
       } finally {
@@ -266,7 +266,7 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       }
     }
     throw new FileQueueException(
-      "[MVStoreFileQueue] Failed to acquire read lock after " + properties.getMaxRetry() + " attempts", exception);
+      "[MVStoreFileQueue] Failed to execute with read lock after " + properties.getMaxRetry() + " attempts", exception);
   }
 
   private void commitIfNeeded() {

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -288,12 +288,17 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
   }
 
   private void doCommit() {
-    if (log.isDebugEnabled()) {
-      log.debug("total={} commits={} batch={} message=commit", totalOperation.get(),
-        totalCommits.get(), properties.getBatchSize());
+    try {
+      if (log.isDebugEnabled()) {
+        log.debug("total={} commits={} batch={} message=commit", totalOperation.get(),
+          totalCommits.get(), properties.getBatchSize());
+      }
+      mvStore.commit();
+      totalCommits.incrementAndGet();
+    } catch (Exception e) {
+      log.error("total={} commits={} batch={} message=commit failed",
+        totalOperation.get(), totalCommits.get(), properties.getBatchSize(), e);
     }
-    mvStore.commit();
-    totalCommits.incrementAndGet();
   }
 
   @FunctionalInterface

--- a/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
+++ b/src/main/java/io/github/ppzxc/fq/MVStoreFileQueue.java
@@ -120,11 +120,13 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
       }
     }
     return executeWithWriteLock(() -> {
-      if (size() + value.size() >= properties.getMaxSize()) {
+      if (size() + value.size() > properties.getMaxSize()) {
         throw new FileQueueException("[MVStoreFileQueue] Queue is full: size " + size() + " >= maxSize " + properties.getMaxSize());
       }
-      value.forEach(v -> queue.put(tail.getAndIncrement(), v));
-      commitIfNeeded();
+      value.forEach(v -> {
+        queue.put(tail.getAndIncrement(), v);
+        commitIfNeeded();
+      });
       return true;
     });
   }
@@ -189,16 +191,18 @@ class MVStoreFileQueue<T extends Serializable> implements FileQueue<T> {
     if (closed) {
       return;
     }
-    executeWithWriteLock(() -> {
+    lock.writeLock().lock();
+    try {
       if (closed) {
-        return null;
+        return;
       }
       closed = true;
       long newVersion = mvStore.commit();
       log.info("newVersion={} message=close", newVersion);
       mvStore.close();
-      return null;
-    });
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   private void checkClosed() {

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
@@ -217,7 +217,7 @@ class MVStoreFileQueueAdditionalTest {
   void enqueue_afterDequeueAtMaxSizeBoundary() {
     // given
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
-    properties.setMaxSize(11); // >= check, so maxSize=11 allows 10 items
+    properties.setMaxSize(11); // single enqueue: >= check, so maxSize=11 allows up to 10 items via single enqueue
     String path = tempDir.resolve("boundary2.db").toFile().getAbsolutePath();
     queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
 
@@ -235,16 +235,18 @@ class MVStoreFileQueueAdditionalTest {
   }
 
   /**
-   * maxSize=10인 큐에 5개가 있을 때 5개짜리 배치를 삽입하면 예외가 발생하는지 검증한다.
+   * maxSize=10인 큐에 5개가 있을 때 정확히 5개 배치 삽입은 성공하고,
+   * 6개 배치 삽입은 실패하는지 검증한다.
    * <p>
-   * size(5) + list.size(5) = 10 &gt;= maxSize(10) 조건으로 실패해야 하며,
-   * 4개짜리 배치(9 &lt; 10)는 성공해야 한다.
+   * 배치 체크: size() + list.size() &gt; maxSize<br>
+   * - size(5) + batch.size(5) = 10, 10 &gt; 10은 false → 성공 (큐를 가득 채울 수 있음)<br>
+   * - size(10) + batch.size(1) = 11, 11 &gt; 10은 true → 실패
    * </p>
    */
   @DisplayName("batch enqueue at maxSize boundary")
   @Test
   void batchEnqueue_atMaxSizeBoundary() {
-    // given - batch enqueue uses size() + value.size() >= maxSize check
+    // given
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setMaxSize(10);
     String path = tempDir.resolve("batch_boundary.db").toFile().getAbsolutePath();
@@ -255,19 +257,15 @@ class MVStoreFileQueueAdditionalTest {
       queue.enqueue("item-" + i);
     }
 
-    // when - try to add 5 more (would make size + list.size = 10, which >= maxSize)
+    // when - size(5) + batch.size(5) = 10 > 10 은 false → 성공 (배치로 최대 용량까지 채울 수 있음)
     List<String> batch = Arrays.asList("batch-0", "batch-1", "batch-2", "batch-3", "batch-4");
+    queue.enqueue(batch);
+    assertThat(queue.size()).isEqualTo(10);
 
-    // then - should fail because size(5) + batch.size(5) = 10 >= maxSize(10)
-    // FileQueueException is propagated immediately (no retry wrapper)
-    assertThatThrownBy(() -> queue.enqueue(batch))
+    // when - 큐가 가득 찬 상태(size=10)에서 단 1개 배치도 초과 → 실패
+    assertThatThrownBy(() -> queue.enqueue(Arrays.asList("overflow")))
         .isInstanceOf(FileQueueException.class)
         .hasMessageContaining("Queue is full");
-
-    // Verify a smaller batch succeeds
-    List<String> smallBatch = Arrays.asList("small-0", "small-1", "small-2", "small-3");
-    queue.enqueue(smallBatch); // size(5) + 4 = 9 < 10, should succeed
-    assertThat(queue.size()).isEqualTo(9);
   }
 
   /**

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
@@ -202,7 +202,7 @@ class MVStoreFileQueueAdditionalTest {
     // Note: acquireWriteLock wraps the original exception, so we check the root cause
     assertThatThrownBy(() -> queue.enqueue("item-10"))
         .isInstanceOf(FileQueueException.class)
-        .hasRootCauseMessage("[MVStoreFileQueue] Queue is full: size 10 >= maxSize 10");
+        .hasMessage("[MVStoreFileQueue] Queue is full: size 10 >= maxSize 10");
   }
 
   /**
@@ -259,10 +259,10 @@ class MVStoreFileQueueAdditionalTest {
     List<String> batch = Arrays.asList("batch-0", "batch-1", "batch-2", "batch-3", "batch-4");
 
     // then - should fail because size(5) + batch.size(5) = 10 >= maxSize(10)
-    // Note: acquireWriteLock wraps the original exception
+    // FileQueueException is propagated immediately (no retry wrapper)
     assertThatThrownBy(() -> queue.enqueue(batch))
         .isInstanceOf(FileQueueException.class)
-        .hasRootCauseInstanceOf(FileQueueException.class);
+        .hasMessageContaining("Queue is full");
 
     // Verify a smaller batch succeeds
     List<String> smallBatch = Arrays.asList("small-0", "small-1", "small-2", "small-3");

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
@@ -202,7 +202,7 @@ class MVStoreFileQueueAdditionalTest {
     // Note: acquireWriteLock wraps the original exception, so we check the root cause
     assertThatThrownBy(() -> queue.enqueue("item-10"))
         .isInstanceOf(FileQueueException.class)
-        .hasRootCauseMessage("[MVStoreFileQueue] Queue is full: 10 > 10");
+        .hasRootCauseMessage("[MVStoreFileQueue] Queue is full: size 10 >= maxSize 10");
   }
 
   /**

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueAdditionalTest.java
@@ -1,0 +1,1130 @@
+package io.github.ppzxc.fq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MVStoreFileQueueAdditionalTest {
+
+  @TempDir
+  Path tempDir;
+
+  private FileQueue<String> queue;
+
+  @AfterEach
+  void tearDown() {
+    if (queue != null) {
+      try {
+        queue.close();
+      } catch (Exception e) {
+        // ignore - queue may already be closed
+      }
+    }
+  }
+
+  /**
+   * enqueue 작업 중 큐를 close하면 진행 중인 스레드들이 IllegalStateException을 받고
+   * 모두 정상 종료되는지 검증한다.
+   * <p>
+   * close 이전에 성공한 enqueue가 1개 이상 존재해야 하며,
+   * close 이후 enqueue 시도는 IllegalStateException으로 처리되어야 한다.
+   * </p>
+   */
+  @DisplayName("concurrent close while enqueue operations in flight")
+  @Test
+  void concurrentClose_whileEnqueueInFlight() throws Exception {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("concurrent_close.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    int threadCount = 5;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicInteger successCount = new AtomicInteger(0);
+    AtomicInteger exceptionCount = new AtomicInteger(0);
+    AtomicBoolean closeCalled = new AtomicBoolean(false);
+
+    // when - start enqueue threads
+    for (int i = 0; i < threadCount; i++) {
+      final int threadId = i;
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          for (int j = 0; j < 10000; j++) {
+            if (closeCalled.get()) {
+              // Try one more operation after close to verify exception
+              try {
+                queue.enqueue("after-close-" + threadId);
+              } catch (IllegalStateException e) {
+                exceptionCount.incrementAndGet();
+              }
+              break;
+            }
+            queue.enqueue("item-" + threadId + "-" + j);
+            successCount.incrementAndGet();
+          }
+        } catch (IllegalStateException e) {
+          // Expected when queue is closed
+          exceptionCount.incrementAndGet();
+        } catch (Exception e) {
+          // Other exceptions
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    Thread.sleep(5); // Let some enqueue operations happen
+    closeCalled.set(true);
+    queue.close();
+
+    boolean completed = doneLatch.await(5, TimeUnit.SECONDS);
+    executor.shutdownNow();
+
+    // then - all threads should complete and some operations succeeded before close
+    assertThat(completed).isTrue();
+    assertThat(successCount.get()).isGreaterThan(0);
+  }
+
+  /**
+   * dequeue 작업 중 큐를 close하면 진행 중인 스레드들이 IllegalStateException을 받고
+   * 모두 정상 종료되는지 검증한다.
+   * <p>
+   * close 이전에 성공한 dequeue가 1개 이상 존재해야 하며,
+   * 모든 스레드가 5초 이내에 완료되어야 한다.
+   * </p>
+   */
+  @DisplayName("concurrent close while dequeue operations in flight")
+  @Test
+  void concurrentClose_whileDequeueInFlight() throws Exception {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("concurrent_close_dequeue.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // Pre-populate queue
+    for (int i = 0; i < 10000; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    int threadCount = 5;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicInteger dequeueCount = new AtomicInteger(0);
+    AtomicBoolean closeCalled = new AtomicBoolean(false);
+
+    // when - start dequeue threads
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          while (!closeCalled.get()) {
+            String item = queue.dequeue();
+            if (item != null) {
+              dequeueCount.incrementAndGet();
+            }
+          }
+          // Try one more operation after close
+          queue.dequeue();
+        } catch (IllegalStateException e) {
+          // Expected when queue is closed
+        } catch (Exception e) {
+          // Other exceptions
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    Thread.sleep(5);
+    closeCalled.set(true);
+    queue.close();
+
+    boolean completed = doneLatch.await(5, TimeUnit.SECONDS);
+    executor.shutdownNow();
+
+    // then - all threads completed and some items were dequeued
+    assertThat(completed).isTrue();
+    assertThat(dequeueCount.get()).isGreaterThan(0);
+  }
+
+  /**
+   * maxSize=10인 큐에 정확히 10개의 아이템을 삽입한 후 11번째 삽입 시 예외가 발생하는지 검증한다.
+   * <p>
+   * size >= maxSize 조건(10 >= 10)이 충족되면 큐가 가득 찬 것으로 간주하며,
+   * FileQueueException의 root cause 메시지가 올바른지 확인한다.
+   * </p>
+   */
+  @DisplayName("enqueue at exact maxSize boundary - fill to maxSize-1 then add one more")
+  @Test
+  void enqueue_atExactMaxSizeBoundary() {
+    // given - maxSize uses >= check, so maxSize=10 allows 0-9 items (10 items fails)
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxSize(10);
+    String path = tempDir.resolve("boundary.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when - fill to maxSize (10 items, which triggers size >= maxSize)
+    for (int i = 0; i < 10; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // then - should have 10 items
+    assertThat(queue.size()).isEqualTo(10);
+
+    // when - try to add one more (should fail because size=10 >= maxSize=10)
+    // Note: acquireWriteLock wraps the original exception, so we check the root cause
+    assertThatThrownBy(() -> queue.enqueue("item-10"))
+        .isInstanceOf(FileQueueException.class)
+        .hasRootCauseMessage("[MVStoreFileQueue] Queue is full: 10 > 10");
+  }
+
+  /**
+   * maxSize=11인 큐에 10개를 채우고 1개를 dequeue한 후 새 아이템을 추가할 수 있는지 검증한다.
+   * <p>
+   * dequeue 후 size(9) + 1 = 10 &lt; maxSize(11)이므로 enqueue가 성공해야 하며,
+   * 최종 큐 크기는 10이어야 한다.
+   * </p>
+   */
+  @DisplayName("enqueue after dequeue at maxSize boundary")
+  @Test
+  void enqueue_afterDequeueAtMaxSizeBoundary() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxSize(11); // >= check, so maxSize=11 allows 10 items
+    String path = tempDir.resolve("boundary2.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // Fill to 10 items
+    for (int i = 0; i < 10; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // when - dequeue one and try to add
+    queue.dequeue();
+    queue.enqueue("new-item");
+
+    // then
+    assertThat(queue.size()).isEqualTo(10);
+  }
+
+  /**
+   * maxSize=10인 큐에 5개가 있을 때 5개짜리 배치를 삽입하면 예외가 발생하는지 검증한다.
+   * <p>
+   * size(5) + list.size(5) = 10 &gt;= maxSize(10) 조건으로 실패해야 하며,
+   * 4개짜리 배치(9 &lt; 10)는 성공해야 한다.
+   * </p>
+   */
+  @DisplayName("batch enqueue at maxSize boundary")
+  @Test
+  void batchEnqueue_atMaxSizeBoundary() {
+    // given - batch enqueue uses size() + value.size() >= maxSize check
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxSize(10);
+    String path = tempDir.resolve("batch_boundary.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // Fill to 5 items
+    for (int i = 0; i < 5; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // when - try to add 5 more (would make size + list.size = 10, which >= maxSize)
+    List<String> batch = Arrays.asList("batch-0", "batch-1", "batch-2", "batch-3", "batch-4");
+
+    // then - should fail because size(5) + batch.size(5) = 10 >= maxSize(10)
+    // Note: acquireWriteLock wraps the original exception
+    assertThatThrownBy(() -> queue.enqueue(batch))
+        .isInstanceOf(FileQueueException.class)
+        .hasRootCauseInstanceOf(FileQueueException.class);
+
+    // Verify a smaller batch succeeds
+    List<String> smallBatch = Arrays.asList("small-0", "small-1", "small-2", "small-3");
+    queue.enqueue(smallBatch); // size(5) + 4 = 9 < 10, should succeed
+    assertThat(queue.size()).isEqualTo(9);
+  }
+
+  /**
+   * dequeue(int)에 현재 큐 크기와 정확히 같은 수를 전달하면 모든 아이템이 반환되고
+   * 큐가 비어있는지 검증한다.
+   * <p>FIFO 순서도 함께 검증한다.</p>
+   */
+  @DisplayName("dequeue with size exactly equal to queue size")
+  @Test
+  void dequeue_withSizeExactlyEqualToQueueSize() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("exact_dequeue.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    int itemCount = 50;
+    for (int i = 0; i < itemCount; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // when
+    List<String> dequeued = queue.dequeue(itemCount);
+
+    // then
+    assertThat(dequeued).hasSize(itemCount);
+    assertThat(queue.isEmpty()).isTrue();
+    assertThat(queue.size()).isZero();
+
+    // Verify order
+    for (int i = 0; i < itemCount; i++) {
+      assertThat(dequeued.get(i)).isEqualTo("item-" + i);
+    }
+  }
+
+  /**
+   * dequeue(int)에 현재 큐 크기보다 큰 수를 전달하면 현재 존재하는 모든 아이템만 반환되는지 검증한다.
+   */
+  @DisplayName("dequeue with size larger than queue size returns available items")
+  @Test
+  void dequeue_withSizeLargerThanQueueSize() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("larger_dequeue.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    queue.enqueue("item-0");
+    queue.enqueue("item-1");
+    queue.enqueue("item-2");
+
+    // when
+    List<String> dequeued = queue.dequeue(100);
+
+    // then
+    assertThat(dequeued).hasSize(3);
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * 빈 큐에서 compactFile()을 호출해도 예외가 발생하지 않고
+   * 이후 enqueue/dequeue가 정상 동작하는지 검증한다.
+   */
+  @DisplayName("compact with empty queue")
+  @Test
+  void compact_withEmptyQueue() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setCompactByFileSize(1); // Very small threshold
+    String path = tempDir.resolve("empty_compact.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when - compact empty queue
+    queue.compactFile();
+
+    // then - no exception and queue still functional
+    assertThat(queue.isEmpty()).isTrue();
+    queue.enqueue("test");
+    assertThat(queue.dequeue()).isEqualTo("test");
+  }
+
+  /**
+   * enqueue/dequeue/compactFile이 동시에 실행되어도 교착상태(deadlock)가 발생하지 않는지 검증한다.
+   * <p>
+   * 200회의 enqueue, 지속적인 dequeue, 5회의 compactFile이 10초 이내에 완료되어야 한다.
+   * </p>
+   */
+  @DisplayName("compact while concurrent enqueue/dequeue operations")
+  @Test
+  void compact_whileConcurrentOperations() throws Exception {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setCompactByFileSize(1);
+    String path = tempDir.resolve("concurrent_compact.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(3);
+    AtomicBoolean running = new AtomicBoolean(true);
+    Set<String> enqueuedItems = ConcurrentHashMap.newKeySet();
+    Set<String> dequeuedItems = ConcurrentHashMap.newKeySet();
+
+    // Enqueue thread
+    executor.submit(() -> {
+      try {
+        startLatch.await();
+        int count = 0;
+        while (running.get() && count < 200) {
+          String item = "item-" + count++;
+          queue.enqueue(item);
+          enqueuedItems.add(item);
+        }
+      } catch (Exception e) {
+        // ignore
+      } finally {
+        doneLatch.countDown();
+      }
+    });
+
+    // Dequeue thread
+    executor.submit(() -> {
+      try {
+        startLatch.await();
+        while (running.get()) {
+          String item = queue.dequeue();
+          if (item != null) {
+            dequeuedItems.add(item);
+          }
+        }
+      } catch (Exception e) {
+        // ignore
+      } finally {
+        doneLatch.countDown();
+      }
+    });
+
+    // Compact thread
+    executor.submit(() -> {
+      try {
+        startLatch.await();
+        for (int i = 0; i < 5; i++) {
+          Thread.sleep(20);
+          queue.compactFile();
+        }
+      } catch (Exception e) {
+        // ignore
+      } finally {
+        running.set(false);
+        doneLatch.countDown();
+      }
+    });
+
+    startLatch.countDown();
+    boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+    executor.shutdownNow();
+
+    // then - no deadlock occurred
+    assertThat(completed).isTrue();
+  }
+
+  /**
+   * batchSize=1(연산마다 커밋)이고 autoCommitDisabled=true일 때 500개의 아이템을 삽입하면
+   * 모두 정확하게 FIFO 순서로 조회되는지 검증한다.
+   */
+  @DisplayName("very small batchSize with many operations")
+  @Test
+  void smallBatchSize_withManyOperations() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setBatchSize(1); // Commit after every operation
+    properties.setAutoCommitDisabled(true);
+    String path = tempDir.resolve("small_batch.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    int itemCount = 500;
+
+    // when
+    for (int i = 0; i < itemCount; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // then
+    assertThat(queue.size()).isEqualTo(itemCount);
+
+    // Verify all items are retrievable
+    for (int i = 0; i < itemCount; i++) {
+      String item = queue.dequeue();
+      assertThat(item).isEqualTo("item-" + i);
+    }
+  }
+
+  /**
+   * batchSize보다 적은 아이템을 삽입하고 close한 후 재오픈 시 모든 아이템이 복구되는지 검증한다.
+   * <p>
+   * close() 호출 시 미커밋 데이터를 강제로 commit하여 영속성을 보장해야 한다.
+   * 재오픈 후 50개의 아이템이 존재하고 첫 번째 아이템이 "item-0"이어야 한다.
+   * </p>
+   */
+  @DisplayName("recovery after close and reopen with uncommitted data")
+  @Test
+  void recovery_afterCloseAndReopen() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setBatchSize(100); // Large batch size
+    String path = tempDir.resolve("recovery.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // Enqueue some items (less than batch size, so no auto-commit)
+    for (int i = 0; i < 50; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // Close (should commit remaining)
+    queue.close();
+
+    // Reopen
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // then - all items should be recovered
+    assertThat(queue.size()).isEqualTo(50);
+    assertThat(queue.dequeue()).isEqualTo("item-0");
+  }
+
+  /**
+   * 20번의 open → enqueue → close 사이클을 반복한 후 재오픈 시 20개의 아이템이 모두 존재하는지 검증한다.
+   * <p>반복적인 open/close가 데이터 손실 없이 누적 저장됨을 확인한다.</p>
+   */
+  @DisplayName("rapid open/close cycles")
+  @Test
+  void rapidOpenCloseCycles() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("rapid_cycle.db").toFile().getAbsolutePath();
+
+    // when - rapid open/close cycles
+    for (int cycle = 0; cycle < 20; cycle++) {
+      queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+      queue.enqueue("item-" + cycle);
+      queue.close();
+    }
+
+    // then - final reopen should have all items
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    assertThat(queue.size()).isEqualTo(20);
+  }
+
+  /**
+   * 한글, 일본어, 중국어, 이모지, 특수문자, 개행 문자 등 다양한 유니코드 문자열이
+   * 직렬화/역직렬화 과정에서 손실 없이 보존되는지 검증한다.
+   */
+  @DisplayName("unicode and special character data")
+  @Test
+  void unicodeAndSpecialCharacterData() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("unicode.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when - enqueue various unicode strings
+    List<String> testStrings = Arrays.asList(
+        "한글 테스트",
+        "日本語テスト",
+        "中文测试",
+        "🎉🚀💯",
+        "emoji: 😀🎈🎁",
+        "mixed: Hello 世界 🌍",
+        "special chars: <>&\"'",
+        "newlines:\n\r\t",
+        "null char before: \u0000 after",
+        ""
+    );
+
+    for (String s : testStrings) {
+      queue.enqueue(s);
+    }
+
+    // then - all strings should be dequeued correctly
+    for (String expected : testStrings) {
+      String actual = queue.dequeue();
+      assertThat(actual).isEqualTo(expected);
+    }
+  }
+
+  /**
+   * id, name, items 필드를 가진 복잡한 직렬화 객체가 enqueue/dequeue 후에도
+   * 모든 필드 값이 동일하게 유지되는지 검증한다.
+   * <p>한글 문자열 필드도 포함하여 직렬화 무결성을 확인한다.</p>
+   */
+  @DisplayName("complex serializable object")
+  @Test
+  void complexSerializableObject() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("complex.db").toFile().getAbsolutePath();
+    FileQueue<TestObject> objectQueue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    try {
+      TestObject obj1 = new TestObject(1, "test", Arrays.asList("a", "b", "c"));
+      TestObject obj2 = new TestObject(2, "한글", Arrays.asList("가", "나", "다"));
+
+      // when
+      objectQueue.enqueue(obj1);
+      objectQueue.enqueue(obj2);
+
+      // then
+      TestObject dequeued1 = objectQueue.dequeue();
+      TestObject dequeued2 = objectQueue.dequeue();
+
+      assertThat(dequeued1).isEqualTo(obj1);
+      assertThat(dequeued2).isEqualTo(obj2);
+    } finally {
+      objectQueue.close();
+    }
+  }
+
+  /**
+   * metric() 호출 시 다양한 이름(영문, 빈 문자열, 한글)에 대해 예외가 발생하지 않는지 검증한다.
+   */
+  @DisplayName("metric logging does not throw")
+  @Test
+  void metric_doesNotThrow() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("metric.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    queue.enqueue("item1");
+    queue.enqueue("item2");
+    queue.dequeue();
+
+    // when/then - should not throw
+    queue.metric("test-metric");
+    queue.metric("");
+    queue.metric("한글메트릭");
+  }
+
+  /**
+   * fileName()이 큐 생성 시 전달한 절대 경로를 정확히 반환하는지 검증한다.
+   */
+  @DisplayName("fileName returns correct path")
+  @Test
+  void fileName_returnsCorrectPath() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("filename_test.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when
+    String fileName = queue.fileName();
+
+    // then
+    assertThat(fileName).isEqualTo(path);
+  }
+
+  /**
+   * 큐를 닫은 후 모든 연산이 "closed" 메시지를 포함한 IllegalStateException을 던지는지 검증한다.
+   * <p>
+   * enqueue(T), enqueue(List), dequeue(), dequeue(int), isEmpty(), size(), compactFile() 모두
+   * IllegalStateException을 발생시켜야 한다.
+   * </p>
+   */
+  @DisplayName("operations after close throw IllegalStateException")
+  @Test
+  void operationsAfterClose_throwIllegalStateException() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("closed.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    queue.close();
+
+    // then
+    assertThatThrownBy(() -> queue.enqueue("test"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.enqueue(Arrays.asList("a", "b")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.dequeue())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.dequeue(5))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.isEmpty())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.size())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+
+    assertThatThrownBy(() -> queue.compactFile())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed");
+  }
+
+  /**
+   * enqueue(List)에 빈 리스트를 전달하면 true를 반환하고 큐가 비어있는지 검증한다.
+   */
+  @DisplayName("empty list enqueue returns true")
+  @Test
+  void emptyListEnqueue_returnsTrue() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("empty_list.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when
+    boolean result = queue.enqueue(new ArrayList<>());
+
+    // then
+    assertThat(result).isTrue();
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * dequeue(0) 호출 시 빈 리스트를 반환하고 기존 아이템이 그대로 유지되는지 검증한다.
+   */
+  @DisplayName("dequeue with zero size returns empty list")
+  @Test
+  void dequeueWithZeroSize_returnsEmptyList() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("zero_dequeue.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    queue.enqueue("item");
+
+    // when
+    List<String> result = queue.dequeue(0);
+
+    // then
+    assertThat(result).isEmpty();
+    assertThat(queue.size()).isEqualTo(1);
+  }
+
+  /**
+   * dequeue(-1) 호출 시 "negative" 메시지를 포함한 IllegalArgumentException이 발생하는지 검증한다.
+   */
+  @DisplayName("dequeue with negative size throws exception")
+  @Test
+  void dequeueWithNegativeSize_throwsException() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("negative_dequeue.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when/then
+    assertThatThrownBy(() -> queue.dequeue(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("negative");
+  }
+
+  /**
+   * enqueue/dequeue가 교차로 수행될 때 FIFO 순서가 올바르게 유지되는지 검증한다.
+   * <p>
+   * 1, 2 enqueue → 1 dequeue → 3, 4 enqueue → 2, 3 dequeue → 5 enqueue
+   * → 4, 5 dequeue 순서가 정확히 보장되어야 한다.
+   * </p>
+   */
+  @DisplayName("FIFO order maintained after multiple operations")
+  @Test
+  void fifoOrder_maintainedAfterMultipleOperations() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("fifo.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when - interleaved enqueue/dequeue
+    queue.enqueue("1");
+    queue.enqueue("2");
+    assertThat(queue.dequeue()).isEqualTo("1");
+    queue.enqueue("3");
+    queue.enqueue("4");
+    assertThat(queue.dequeue()).isEqualTo("2");
+    assertThat(queue.dequeue()).isEqualTo("3");
+    queue.enqueue("5");
+
+    // then
+    assertThat(queue.dequeue()).isEqualTo("4");
+    assertThat(queue.dequeue()).isEqualTo("5");
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * 압축 활성화 큐와 비활성화 큐가 동일한 데이터를 100개 삽입했을 때
+   * 두 큐 모두 동일한 크기와 순서로 데이터를 반환하는지 검증한다.
+   */
+  @DisplayName("compression enabled vs disabled")
+  @Test
+  void compression_enabledVsDisabled() {
+    // given
+    MVStoreFileQueueProperties propsCompressed = new MVStoreFileQueueProperties();
+    propsCompressed.setUseCompress(true);
+    String pathCompressed = tempDir.resolve("compressed.db").toFile().getAbsolutePath();
+
+    MVStoreFileQueueProperties propsUncompressed = new MVStoreFileQueueProperties();
+    propsUncompressed.setUseCompress(false);
+    String pathUncompressed = tempDir.resolve("uncompressed.db").toFile().getAbsolutePath();
+
+    FileQueue<String> compressedQueue = FileQueueFactory.createMVStoreFileQueue(pathCompressed, propsCompressed);
+    FileQueue<String> uncompressedQueue = FileQueueFactory.createMVStoreFileQueue(pathUncompressed, propsUncompressed);
+
+    try {
+      // when - add same data to both
+      String largeData = "x".repeat(1000);
+      for (int i = 0; i < 100; i++) {
+        compressedQueue.enqueue(largeData + i);
+        uncompressedQueue.enqueue(largeData + i);
+      }
+
+      // then - both should work correctly
+      assertThat(compressedQueue.size()).isEqualTo(100);
+      assertThat(uncompressedQueue.size()).isEqualTo(100);
+
+      // Verify data integrity
+      for (int i = 0; i < 100; i++) {
+        assertThat(compressedQueue.dequeue()).isEqualTo(largeData + i);
+        assertThat(uncompressedQueue.dequeue()).isEqualTo(largeData + i);
+      }
+    } finally {
+      compressedQueue.close();
+      uncompressedQueue.close();
+    }
+  }
+
+  /**
+   * 공정 락(fair=true) 큐와 비공정 락(fair=false) 큐가 동시 접근 시
+   * 두 큐 모두 정확히 threadCount × opsPerThread 개의 아이템을 저장하는지 검증한다.
+   */
+  @DisplayName("fair vs unfair lock mode")
+  @Test
+  void fairVsUnfairLockMode() throws Exception {
+    // given
+    MVStoreFileQueueProperties fairProps = new MVStoreFileQueueProperties();
+    fairProps.setFair(true);
+    String fairPath = tempDir.resolve("fair.db").toFile().getAbsolutePath();
+
+    MVStoreFileQueueProperties unfairProps = new MVStoreFileQueueProperties();
+    unfairProps.setFair(false);
+    String unfairPath = tempDir.resolve("unfair.db").toFile().getAbsolutePath();
+
+    FileQueue<Integer> fairQueue = FileQueueFactory.createMVStoreFileQueue(fairPath, fairProps);
+    FileQueue<Integer> unfairQueue = FileQueueFactory.createMVStoreFileQueue(unfairPath, unfairProps);
+
+    try {
+      // when - concurrent operations on both
+      int threadCount = 4;
+      int opsPerThread = 100;
+      ExecutorService executor = Executors.newFixedThreadPool(threadCount * 2);
+      CountDownLatch latch = new CountDownLatch(threadCount * 2);
+      AtomicInteger fairCounter = new AtomicInteger(0);
+      AtomicInteger unfairCounter = new AtomicInteger(0);
+
+      for (int i = 0; i < threadCount; i++) {
+        executor.submit(() -> {
+          try {
+            for (int j = 0; j < opsPerThread; j++) {
+              fairQueue.enqueue(fairCounter.incrementAndGet());
+            }
+          } finally {
+            latch.countDown();
+          }
+        });
+        executor.submit(() -> {
+          try {
+            for (int j = 0; j < opsPerThread; j++) {
+              unfairQueue.enqueue(unfairCounter.incrementAndGet());
+            }
+          } finally {
+            latch.countDown();
+          }
+        });
+      }
+
+      latch.await(10, TimeUnit.SECONDS);
+      executor.shutdownNow();
+
+      // then - both should have all items
+      assertThat(fairQueue.size()).isEqualTo(threadCount * opsPerThread);
+      assertThat(unfairQueue.size()).isEqualTo(threadCount * opsPerThread);
+    } finally {
+      fairQueue.close();
+      unfairQueue.close();
+    }
+  }
+
+  /**
+   * 10개 enqueue, 5개 dequeue 후 close하고 재오픈 시 head/tail 포인터가
+   * 올바르게 복원되어 남은 5개 아이템이 순서대로 조회되는지 검증한다.
+   */
+  @DisplayName("head and tail pointers correct after reopen")
+  @Test
+  void headTailPointers_correctAfterReopen() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("pointers.db").toFile().getAbsolutePath();
+
+    // First session: enqueue 10, dequeue 5
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    for (int i = 0; i < 10; i++) {
+      queue.enqueue("item-" + i);
+    }
+    for (int i = 0; i < 5; i++) {
+      queue.dequeue();
+    }
+    queue.close();
+
+    // Reopen
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // then - should have 5 items starting from item-5
+    assertThat(queue.size()).isEqualTo(5);
+    assertThat(queue.dequeue()).isEqualTo("item-5");
+    assertThat(queue.dequeue()).isEqualTo("item-6");
+  }
+
+  /**
+   * close()를 3번 연속 호출해도 예외가 발생하지 않는지(멱등성) 검증한다.
+   */
+  @DisplayName("multiple close calls are idempotent")
+  @Test
+  void multipleClose_isIdempotent() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("multi_close.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    queue.enqueue("item");
+
+    // when/then - multiple close calls should not throw
+    queue.close();
+    queue.close();
+    queue.close();
+  }
+
+  /**
+   * 10,000개의 아이템을 삽입하고 모두 FIFO 순서로 조회할 수 있는지 검증하는 스트레스 테스트이다.
+   * <p>batchSize=500으로 20번의 자동 커밋이 발생하며, 데이터 무결성을 확인한다.</p>
+   */
+  @DisplayName("high volume stress test")
+  @Test
+  void highVolumeStressTest() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setBatchSize(500);
+    String path = tempDir.resolve("stress.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    int itemCount = 10000;
+
+    // when - high volume enqueue
+    for (int i = 0; i < itemCount; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // then
+    assertThat(queue.size()).isEqualTo(itemCount);
+
+    // Dequeue all
+    for (int i = 0; i < itemCount; i++) {
+      String item = queue.dequeue();
+      assertThat(item).isEqualTo("item-" + i);
+    }
+
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * metric()은 checkClosed() 가드가 없으므로 close() 이후에도 예외 없이 호출 가능한지 검증한다.
+   * <p>
+   * metric()은 내부 상태(totalOperation, totalCommits, head, tail)를 로그로 출력하는 용도이며,
+   * 큐가 닫힌 후에도 AtomicLong 값은 읽을 수 있어야 한다.
+   * </p>
+   */
+  @DisplayName("metric can be called after close without exception")
+  @Test
+  void metric_calledAfterClose_doesNotThrow() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("metric_after_close.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    queue.enqueue("item1");
+    queue.enqueue("item2");
+    queue.dequeue();
+    queue.close();
+
+    // when/then - metric() has no checkClosed() guard, so it should not throw
+    assertThatCode(() -> queue.metric("after-close-metric"))
+        .doesNotThrowAnyException();
+  }
+
+  /**
+   * enqueue(List)에 단일 원소 리스트를 전달하면 큐 크기가 1이 되고
+   * dequeue 시 해당 원소가 반환되는지 검증한다.
+   */
+  @DisplayName("enqueue single element list succeeds")
+  @Test
+  void enqueue_singleElementList_success() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("single_list.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when
+    boolean result = queue.enqueue(Arrays.asList("only-item"));
+
+    // then
+    assertThat(result).isTrue();
+    assertThat(queue.size()).isEqualTo(1);
+    assertThat(queue.dequeue()).isEqualTo("only-item");
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * autoCommitDisabled=true일 때 정확히 batchSize개의 아이템을 삽입하면
+   * 수동 커밋이 1회 발생하고 모든 데이터가 저장되는지 검증한다.
+   * <p>
+   * close 후 재오픈 시 batchSize개 아이템이 복구되어 영속성이 보장됨을 확인한다.
+   * </p>
+   */
+  @DisplayName("batch enqueue of exactly batchSize items triggers one commit")
+  @Test
+  void batchEnqueue_exactlyBatchSizeItems_triggersCommit() {
+    // given
+    int batchSize = 10;
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setBatchSize(batchSize);
+    properties.setAutoCommitDisabled(true);
+    String path = tempDir.resolve("exact_batch.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // when - enqueue exactly batchSize items to trigger exactly one commit
+    for (int i = 0; i < batchSize; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    // then - all items should be present
+    assertThat(queue.size()).isEqualTo(batchSize);
+
+    // close and reopen to verify persistence via commit
+    queue.close();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    assertThat(queue.size()).isEqualTo(batchSize);
+    assertThat(queue.dequeue()).isEqualTo("item-0");
+  }
+
+  /**
+   * 커스텀 queueName으로 저장된 큐를 close 후 재오픈 시 동일한 queueName을 사용하면
+   * 이전에 저장된 데이터가 올바르게 복구되는지 검증한다.
+   */
+  @DisplayName("persistence with custom queue name")
+  @Test
+  void persistence_withCustomQueueName() {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setQueueName("custom-queue");
+    String path = tempDir.resolve("custom_name.db").toFile().getAbsolutePath();
+
+    // when - save with custom queue name
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+    queue.enqueue("item-0");
+    queue.enqueue("item-1");
+    queue.enqueue("item-2");
+    queue.close();
+
+    // reopen with same queueName
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // then - data should be restored correctly
+    assertThat(queue.size()).isEqualTo(3);
+    assertThat(queue.dequeue()).isEqualTo("item-0");
+    assertThat(queue.dequeue()).isEqualTo("item-1");
+    assertThat(queue.dequeue()).isEqualTo("item-2");
+    assertThat(queue.isEmpty()).isTrue();
+  }
+
+  /**
+   * 여러 스레드가 동시에 isEmpty()와 size()를 호출할 때 예외 없이 일관된 결과를 반환하는지 검증한다.
+   * <p>
+   * 읽기 락(read lock)으로 보호되는 isEmpty()와 size()가 동시 호출 시에도
+   * 정상적으로 동작함을 확인한다.
+   * </p>
+   */
+  @DisplayName("concurrent size and isEmpty calls return consistent results")
+  @Test
+  void concurrent_sizeAndIsEmpty_returnConsistentResults() throws Exception {
+    // given
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    String path = tempDir.resolve("concurrent_reads.db").toFile().getAbsolutePath();
+    queue = FileQueueFactory.createMVStoreFileQueue(path, properties);
+
+    // Pre-populate
+    for (int i = 0; i < 100; i++) {
+      queue.enqueue("item-" + i);
+    }
+
+    int threadCount = 8;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    AtomicReference<Throwable> error = new AtomicReference<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          for (int j = 0; j < 50; j++) {
+            long size = queue.size();
+            boolean empty = queue.isEmpty();
+            // size and isEmpty should be consistent: if size==0 then empty must be true
+            if (size == 0 && !empty) {
+              error.set(new AssertionError("Inconsistent state: size=0 but isEmpty=false"));
+            }
+          }
+        } catch (Exception e) {
+          error.set(e);
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+    executor.shutdownNow();
+
+    // then
+    assertThat(completed).isTrue();
+    assertThat(error.get()).isNull();
+  }
+
+  // Helper class for complex object testing
+  private static class TestObject implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final int id;
+    private final String name;
+    private final List<String> items;
+
+    TestObject(int id, String name, List<String> items) {
+      this.id = id;
+      this.name = name;
+      this.items = new ArrayList<>(items);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      TestObject that = (TestObject) o;
+      return id == that.id && Objects.equals(name, that.name) && Objects.equals(items, that.items);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, name, items);
+    }
+  }
+}

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -284,6 +284,33 @@ class MVStoreFileQueueCoverageTest {
   }
 
   /**
+   * lock 내부에서도 closed 상태를 감지하고 IllegalStateException을 즉시 던지는지 검증한다.
+   * <p>
+   * closed 필드를 직접 true로 설정하여 외부 checkClosed()를 우회하고,
+   * lock 내부의 closed 체크가 작동하는지 확인한다.
+   * </p>
+   */
+  @Test
+  void testEnqueue_closedInsideLock_throwsIllegalStateException() throws Exception {
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    MVStoreFileQueue<String> testQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("close-lock-test.db").toString());
+
+    // closed 필드를 직접 true로 설정 (외부 checkClosed()를 우회하여 lock 내부 체크 테스트)
+    java.lang.reflect.Field closedField = MVStoreFileQueue.class.getDeclaredField("closed");
+    closedField.setAccessible(true);
+    closedField.set(testQueue, true);
+
+    // lock 내부에서 closed 감지 → IllegalStateException 즉시 전파 (재시도 없음)
+    assertThatThrownBy(() -> testQueue.enqueue("test"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Queue is already closed");
+
+    assertThatThrownBy(() -> testQueue.isEmpty())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Queue is already closed");
+  }
+
+  /**
    * 큐가 가득 찬 상태에서 enqueue 시 재시도 없이 즉시 FileQueueException이 발생하는지 검증한다.
    * <p>
    * FileQueueException은 비즈니스 로직 예외이므로 재시도 대상이 아니다.
@@ -504,5 +531,93 @@ class MVStoreFileQueueCoverageTest {
     assertThat(method.invoke(ioQueue)).isEqualTo(0L);
 
     ioQueue.close();
+  }
+
+  /**
+   * readableFileSize(0) 호출 시 "0"을 반환하는지 검증한다.
+   * <p>size &le; 0 조건의 early return 브랜치를 커버한다.</p>
+   */
+  @Test
+  void testReadableFileSize_zeroOrNegative() throws Exception {
+    java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("readableFileSize", long.class);
+    method.setAccessible(true);
+    assertThat(method.invoke(queue, 0L)).isEqualTo("0");
+    assertThat(method.invoke(queue, -1L)).isEqualTo("0");
+  }
+
+  /**
+   * executeWithWriteLock의 재시도 루프가 모두 소진될 때 FileQueueException이 발생하는지 검증한다.
+   * <p>
+   * non-business 예외가 maxRetry번 연속 발생하면 마지막 예외를 원인(cause)으로 갖는
+   * FileQueueException이 발생해야 한다.
+   * </p>
+   */
+  @Test
+  void testExecuteWithWriteLock_retryExhausted() throws Exception {
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxRetry(2);
+    properties.setRetryBackoffMs(10);
+
+    MVStoreFileQueue<String> retryQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("retry-write.db").toString());
+
+    java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
+
+    java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("executeWithWriteLock",
+        Class.forName("io.github.ppzxc.fq.MVStoreFileQueue$SupplierWithException"));
+    method.setAccessible(true);
+
+    // 항상 non-business Exception을 던져 재시도를 소진시킨다
+    Object supplier = java.lang.reflect.Proxy.newProxyInstance(
+        MVStoreFileQueue.class.getClassLoader(),
+        new Class[]{Class.forName("io.github.ppzxc.fq.MVStoreFileQueue$SupplierWithException")},
+        (proxy, m, args) -> {
+            count.getAndIncrement();
+            throw new java.io.IOException("Simulated transient I/O failure");
+        }
+    );
+
+    assertThatThrownBy(() -> {
+      try {
+        method.invoke(retryQueue, supplier);
+      } catch (java.lang.reflect.InvocationTargetException e) {
+        throw e.getCause();
+      }
+    })
+        .isInstanceOf(FileQueueException.class)
+        .hasMessageContaining("Failed to execute with write lock after 2 attempts");
+
+    assertThat(count.get()).isEqualTo(2);
+    retryQueue.close();
+  }
+
+  /**
+   * close()가 이미 닫힌 큐에 대해 lock 내부에서 double-check를 수행하는지 검증한다.
+   * <p>
+   * write lock 획득 후 closed=true 확인 시 return null로 빠져나가야 한다.
+   * 이를 위해 volatile closed 필드를 true로 설정한 뒤 close()를 재호출한다.
+   * </p>
+   */
+  @Test
+  void testClose_alreadyClosedInsideLock() throws Exception {
+    // close()의 double-check locking 내부 return null 경로 커버
+    // closed=false로 외부 체크를 통과하지만 lock 획득 전에 closed=true인 상태를 시뮬레이션
+    // 가장 단순한 방법: 첫 번째 close() 정상 실행 후 closed=false 로 되돌리고 재호출
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    MVStoreFileQueue<String> q = new MVStoreFileQueue<>(properties, tempDir.resolve("double-close.db").toString());
+    q.close(); // closed=true, MVStore closed
+
+    // closed를 false로 리셋해서 외부 체크 통과, lock 내부에서 double-check로 잡히도록
+    java.lang.reflect.Field closedField = MVStoreFileQueue.class.getDeclaredField("closed");
+    closedField.setAccessible(true);
+    closedField.set(q, false);
+
+    // 이제 close() 재호출: 외부 checkClosed 통과 → lock 획득 → 내부 double-check에서 return null
+    // (실제로는 MVStore가 이미 닫혀있어서 commit()이 실패할 수도 있지만,
+    //  double-check return null 경로가 실행되어야 한다)
+    try {
+      q.close();
+    } catch (Exception ignored) {
+      // MVStore already closed may throw, but the branch is still covered
+    }
   }
 }

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -172,7 +172,6 @@ class MVStoreFileQueueCoverageTest {
 
     assertThatThrownBy(() -> smallQueue.enqueue("three"))
       .isInstanceOf(FileQueueException.class)
-      .cause()
       .hasMessageContaining("size 2 >= maxSize 2");
 
     smallQueue.close();
@@ -192,7 +191,6 @@ class MVStoreFileQueueCoverageTest {
     List<String> list = Arrays.asList("two", "three");
     assertThatThrownBy(() -> smallQueue.enqueue(list))
       .isInstanceOf(FileQueueException.class)
-      .cause()
       .hasMessageContaining("size 1 >= maxSize 2");
 
     smallQueue.close();
@@ -283,6 +281,33 @@ class MVStoreFileQueueCoverageTest {
     compactQueue.enqueue("test");
     assertThatCode(() -> compactQueue.compactFile()).doesNotThrowAnyException();
     compactQueue.close();
+  }
+
+  /**
+   * 큐가 가득 찬 상태에서 enqueue 시 재시도 없이 즉시 FileQueueException이 발생하는지 검증한다.
+   * <p>
+   * FileQueueException은 비즈니스 로직 예외이므로 재시도 대상이 아니다.
+   * retryBackoffMs=1000ms 설정에서 500ms 이내 실패해야 한다.
+   * </p>
+   */
+  @Test
+  void testEnqueueFullQueue_noRetry() {
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxSize(1);
+    properties.setMaxRetry(3);
+    properties.setRetryBackoffMs(1000);
+    MVStoreFileQueue<String> fullQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("no-retry.db").toString());
+
+    fullQueue.enqueue("first");
+
+    long start = System.nanoTime();
+    assertThatThrownBy(() -> fullQueue.enqueue("second"))
+      .isInstanceOf(FileQueueException.class)
+      .hasMessageContaining("Queue is full");
+    long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+    assertThat(elapsedMs).isLessThan(500);
+    fullQueue.close();
   }
 
   /**

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -591,33 +591,22 @@ class MVStoreFileQueueCoverageTest {
   }
 
   /**
-   * close()가 이미 닫힌 큐에 대해 lock 내부에서 double-check를 수행하는지 검증한다.
+   * close()가 멱등성(idempotent)을 보장하는지 검증한다.
    * <p>
-   * write lock 획득 후 closed=true 확인 시 return null로 빠져나가야 한다.
-   * 이를 위해 volatile closed 필드를 true로 설정한 뒤 close()를 재호출한다.
+   * close()를 여러 번 호출해도 예외가 발생하지 않아야 한다.
+   * 두 번째 close() 호출은 외부 if (closed) 체크 또는 lock 내부 double-check로
+   * 안전하게 no-op 처리되어야 한다.
    * </p>
    */
   @Test
-  void testClose_alreadyClosedInsideLock() throws Exception {
-    // close()의 double-check locking 내부 return null 경로 커버
-    // closed=false로 외부 체크를 통과하지만 lock 획득 전에 closed=true인 상태를 시뮬레이션
-    // 가장 단순한 방법: 첫 번째 close() 정상 실행 후 closed=false 로 되돌리고 재호출
+  void testClose_alreadyClosedInsideLock() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     MVStoreFileQueue<String> q = new MVStoreFileQueue<>(properties, tempDir.resolve("double-close.db").toString());
-    q.close(); // closed=true, MVStore closed
 
-    // closed를 false로 리셋해서 외부 체크 통과, lock 내부에서 double-check로 잡히도록
-    java.lang.reflect.Field closedField = MVStoreFileQueue.class.getDeclaredField("closed");
-    closedField.setAccessible(true);
-    closedField.set(q, false);
+    // 첫 번째 close() — 정상 동작
+    assertThatCode(q::close).doesNotThrowAnyException();
 
-    // 이제 close() 재호출: 외부 checkClosed 통과 → lock 획득 → 내부 double-check에서 return null
-    // (실제로는 MVStore가 이미 닫혀있어서 commit()이 실패할 수도 있지만,
-    //  double-check return null 경로가 실행되어야 한다)
-    try {
-      q.close();
-    } catch (Exception ignored) {
-      // MVStore already closed may throw, but the branch is still covered
-    }
+    // 두 번째 close() — 멱등성: 예외 없이 no-op
+    assertThatCode(q::close).doesNotThrowAnyException();
   }
 }

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -40,19 +40,27 @@ class MVStoreFileQueueCoverageTest {
     }
   }
 
+  /**
+   * 락 획득 대기 중 스레드가 인터럽트되면 backoff 슬립이 중단되고
+   * 인터럽트 상태가 복원되는지 검증한다.
+   * <p>
+   * sleepBackoff() 내부에서 InterruptedException 발생 시
+   * Thread.currentThread().interrupt()가 호출되어 인터럽트 상태가 보존되어야 한다.
+   * </p>
+   */
   @Test
   void testSleepBackoffInterrupted() throws Exception {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setMaxRetry(2);
     properties.setRetryBackoffMs(1000);
-    
+
     MVStoreFileQueue<String> failQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("fail-interrupted.db").toString());
-    
-    java.util.concurrent.locks.ReentrantReadWriteLock lock = (java.util.concurrent.locks.ReentrantReadWriteLock) 
+
+    java.util.concurrent.locks.ReentrantReadWriteLock lock = (java.util.concurrent.locks.ReentrantReadWriteLock)
         org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue(MVStoreFileQueue.class, "lock", failQueue).get();
-    
+
     lock.writeLock().lock(); // Lock it manually
-    
+
     Thread mainThread = Thread.currentThread();
     Thread interruptor = new Thread(() -> {
         try {
@@ -60,9 +68,9 @@ class MVStoreFileQueueCoverageTest {
             mainThread.interrupt();
         } catch (InterruptedException e) {}
     });
-    
+
     interruptor.start();
-    
+
     try {
         failQueue.enqueue("test");
     } catch (FileQueueException e) {
@@ -71,22 +79,30 @@ class MVStoreFileQueueCoverageTest {
         lock.writeLock().unlock();
         Thread.interrupted(); // Clear interrupted status
     }
-    
+
     failQueue.close();
   }
-  
+
+  /**
+   * 디렉터리 경로를 fileName으로 사용하면 MVStore 초기화 실패로 FileQueueException이 발생하는지 검증한다.
+   * <p>예외 메시지는 "Failed to initialize queue"를 포함해야 한다.</p>
+   */
   @Test
   void testConstructorException() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     // Providing a directory path as fileName should cause an exception during MVStore.open()
     String dirPath = tempDir.resolve("a-directory").toString();
     new File(dirPath).mkdirs();
-    
+
     assertThatThrownBy(() -> new MVStoreFileQueue<>(properties, dirPath))
         .isInstanceOf(FileQueueException.class)
         .hasMessageContaining("Failed to initialize queue");
   }
 
+  /**
+   * enqueue(T)에 null을 전달하면 IllegalArgumentException이 발생하는지 검증한다.
+   * <p>예외 메시지는 "value cannot be null"을 포함해야 한다.</p>
+   */
   @Test
   void testEnqueueNullValue() {
     assertThatThrownBy(() -> queue.enqueue((String) null))
@@ -94,6 +110,10 @@ class MVStoreFileQueueCoverageTest {
       .hasMessageContaining("value cannot be null");
   }
 
+  /**
+   * enqueue(List)에 null 리스트를 전달하면 IllegalArgumentException이 발생하는지 검증한다.
+   * <p>예외 메시지는 "value list cannot be null"을 포함해야 한다.</p>
+   */
   @Test
   void testEnqueueNullList() {
     assertThatThrownBy(() -> queue.enqueue((List<String>) null))
@@ -101,11 +121,18 @@ class MVStoreFileQueueCoverageTest {
       .hasMessageContaining("value list cannot be null");
   }
 
+  /**
+   * enqueue(List)에 빈 리스트를 전달하면 true를 반환하고 예외가 발생하지 않는지 검증한다.
+   */
   @Test
   void testEnqueueEmptyList() {
     assertThat(queue.enqueue(Collections.emptyList())).isTrue();
   }
 
+  /**
+   * enqueue(List)에 null 원소가 포함된 리스트를 전달하면 IllegalArgumentException이 발생하는지 검증한다.
+   * <p>예외 메시지는 "value in list cannot be null"을 포함해야 한다.</p>
+   */
   @Test
   void testEnqueueListWithNullElement() {
     List<String> list = Arrays.asList("a", null, "b");
@@ -114,33 +141,44 @@ class MVStoreFileQueueCoverageTest {
       .hasMessageContaining("value in list cannot be null");
   }
 
+  /**
+   * maxSize=1로 설정된 큐에 두 번째 아이템을 삽입하면 FileQueueException이 발생하는지 검증한다.
+   */
   @Test
   void testEnqueueFullQueue() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setMaxSize(1);
     MVStoreFileQueue<String> smallQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("small.db").toString());
-    
+
     smallQueue.enqueue("one");
     assertThatThrownBy(() -> smallQueue.enqueue("two"))
       .isInstanceOf(FileQueueException.class);
-    
+
     smallQueue.close();
   }
 
+  /**
+   * maxSize=2로 설정된 큐에 1개가 있을 때 2개짜리 리스트를 삽입하면 FileQueueException이 발생하는지 검증한다.
+   * <p>size(1) + list.size(2) = 3 &ge; maxSize(2) 조건을 검증한다.</p>
+   */
   @Test
   void testEnqueueListFullQueue() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setMaxSize(2);
     MVStoreFileQueue<String> smallQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("small-list.db").toString());
-    
+
     smallQueue.enqueue("one");
     List<String> list = Arrays.asList("two", "three");
     assertThatThrownBy(() -> smallQueue.enqueue(list))
       .isInstanceOf(FileQueueException.class);
-    
+
     smallQueue.close();
   }
 
+  /**
+   * dequeue(-1) 호출 시 IllegalArgumentException이 발생하는지 검증한다.
+   * <p>예외 메시지는 "size cannot be negative"를 포함해야 한다.</p>
+   */
   @Test
   void testDequeueNegativeSize() {
     assertThatThrownBy(() -> queue.dequeue(-1))
@@ -148,17 +186,27 @@ class MVStoreFileQueueCoverageTest {
       .hasMessageContaining("size cannot be negative");
   }
 
+  /**
+   * dequeue(0) 호출 시 빈 리스트가 반환되는지 검증한다.
+   */
   @Test
   void testDequeueZeroSize() {
     assertThat(queue.dequeue(0)).isEmpty();
   }
 
+  /**
+   * 빈 큐에서 dequeue() 및 dequeue(5) 호출 시 각각 null과 빈 리스트가 반환되는지 검증한다.
+   */
   @Test
   void testDequeueEmptyQueue() {
     assertThat(queue.dequeue()).isNull();
     assertThat(queue.dequeue(5)).isEmpty();
   }
 
+  /**
+   * 큐를 닫은 후 모든 연산(enqueue, dequeue, dequeue(int), size, isEmpty, compactFile)이
+   * IllegalStateException을 던지는지 검증한다.
+   */
   @Test
   void testOperationAfterClose() {
     queue.close();
@@ -170,18 +218,27 @@ class MVStoreFileQueueCoverageTest {
     assertThatThrownBy(() -> queue.compactFile()).isInstanceOf(IllegalStateException.class);
   }
 
+  /**
+   * close()를 두 번 호출해도 예외가 발생하지 않는지(멱등성) 검증한다.
+   */
   @Test
   void testDoubleClose() {
     queue.close();
     assertThatCode(() -> queue.close()).doesNotThrowAnyException();
   }
 
+  /**
+   * metric() 호출이 예외 없이 정상 실행되는지 검증한다.
+   */
   @Test
   void testMetric() {
     queue.enqueue("test");
     assertThatCode(() -> queue.metric("testMetric")).doesNotThrowAnyException();
   }
 
+  /**
+   * compactByFileSize=1 설정으로 compactFile()을 호출하면 실제 압축이 수행되고 예외가 발생하지 않는지 검증한다.
+   */
   @Test
   void testCompactFile() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
@@ -192,16 +249,22 @@ class MVStoreFileQueueCoverageTest {
     compactQueue.close();
   }
 
+  /**
+   * compactByFileSize가 큰 값(1MB)으로 설정되어 임계값 미만일 때 compactFile()이 예외 없이 로그만 출력하는지 검증한다.
+   */
   @Test
   void testCompactFileBelowThreshold() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
-    properties.setCompactByFileSize(1024 * 1024); 
+    properties.setCompactByFileSize(1024 * 1024);
     MVStoreFileQueue<String> compactQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("compact2.db").toString());
     compactQueue.enqueue("test");
     assertThatCode(() -> compactQueue.compactFile()).doesNotThrowAnyException();
     compactQueue.close();
   }
 
+  /**
+   * autoCommitDisabled=true이고 batchSize=1일 때 enqueue마다 수동 커밋이 발생하는지 검증한다.
+   */
   @Test
   void testAutoCommitDisabled() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
@@ -212,23 +275,28 @@ class MVStoreFileQueueCoverageTest {
     commitQueue.close();
   }
 
+  /**
+   * autoCommitDisabled=true이고 batchSize=1일 때 MVStore가 강제로 닫힌 상태에서
+   * enqueue를 시도하면 예외가 발생하는지 검증한다.
+   * <p>내부 commitIfNeeded() 호출 시 MVStore가 닫혀 있으면 예외가 발생해야 한다.</p>
+   */
   @Test
   void testCommitIfNeededException() throws Exception {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setAutoCommitDisabled(true);
     properties.setBatchSize(1);
-    
+
     MVStoreFileQueue<String> mockQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("mock-commit.db").toString());
-    
-    org.h2.mvstore.MVStore mvStore = (org.h2.mvstore.MVStore) 
+
+    org.h2.mvstore.MVStore mvStore = (org.h2.mvstore.MVStore)
         org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue(MVStoreFileQueue.class, "mvStore", mockQueue).get();
-    
+
     mvStore.close(); // Force commit to fail because it's closed
-    
-    // We can't easily make commit() throw an exception that is not caught or handled, 
+
+    // We can't easily make commit() throw an exception that is not caught or handled,
     // but we can try to trigger the paths.
     // In current implementation, mvStore.commit() is called.
-    
+
     try {
         mockQueue.enqueue("test");
     } catch (Exception e) {
@@ -236,22 +304,27 @@ class MVStoreFileQueueCoverageTest {
     }
   }
 
+  /**
+   * acquireReadLock()의 재시도 로직이 처음 2번은 예외를 던지고 3번째에 성공하는 시나리오에서
+   * 올바르게 결과를 반환하는지 검증한다.
+   * <p>리플렉션으로 내부 SupplierWithException을 직접 주입하여 재시도 메커니즘을 검증한다.</p>
+   */
   @Test
   void testAcquireReadLockRetrySuccess() throws Exception {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setMaxRetry(3);
     properties.setRetryBackoffMs(10);
-    
+
     MVStoreFileQueue<String> retryQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("retry-read.db").toString());
-    
+
     java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
-    
+
     // We want to test the retry loop in acquireReadLock.
     // Since it's private, we use reflection to call it or trigger it.
-    java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("acquireReadLock", 
+    java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("executeWithReadLock",
         Class.forName("io.github.ppzxc.fq.MVStoreFileQueue$SupplierWithException"));
     method.setAccessible(true);
-    
+
     Object supplier = java.lang.reflect.Proxy.newProxyInstance(
         MVStoreFileQueue.class.getClassLoader(),
         new Class[]{Class.forName("io.github.ppzxc.fq.MVStoreFileQueue$SupplierWithException")},
@@ -262,14 +335,18 @@ class MVStoreFileQueueCoverageTest {
             return 42L;
         }
     );
-    
+
     Object result = method.invoke(retryQueue, supplier);
     assertThat(result).isEqualTo(42L);
     assertThat(count.get()).isEqualTo(3);
-    
+
     retryQueue.close();
   }
 
+  /**
+   * 리플렉션으로 queueName 필드를 빈 문자열로 변경한 후 큐 생성 시
+   * IllegalArgumentException이 발생하는지 검증한다.
+   */
   @Test
   void testConstructorEmptyQueueName() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
@@ -277,13 +354,17 @@ class MVStoreFileQueueCoverageTest {
         java.lang.reflect.Field field = MVStoreFileQueueProperties.class.getDeclaredField("queueName");
         field.setAccessible(true);
         field.set(properties, "");
-        
+
         assertThatThrownBy(() -> new MVStoreFileQueue<>(properties, tempDir.resolve("empty-name.db").toString()))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("queueName cannot be null or empty");
     } catch (Exception e) {}
   }
 
+  /**
+   * 리플렉션으로 queueName 필드를 null로 변경한 후 큐 생성 시
+   * IllegalArgumentException이 발생하는지 검증한다.
+   */
   @Test
   void testConstructorNullQueueName() {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
@@ -291,13 +372,20 @@ class MVStoreFileQueueCoverageTest {
         java.lang.reflect.Field field = MVStoreFileQueueProperties.class.getDeclaredField("queueName");
         field.setAccessible(true);
         field.set(properties, null);
-        
+
         assertThatThrownBy(() -> new MVStoreFileQueue<>(properties, tempDir.resolve("null-name.db").toString()))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("queueName cannot be null or empty");
     } catch (Exception e) {}
   }
-  
+
+  /**
+   * abbreviate() 메서드가 모든 TimeUnit 값에 대해 올바른 단위 약어를 반환하는지 검증한다.
+   * <p>
+   * ns(나노초), μs(마이크로초), ms(밀리초), s(초), min(분), h(시간), d(일)을
+   * 각 TimeUnit에 대해 검증한다.
+   * </p>
+   */
   @Test
   void testAbbreviate() throws Exception {
     java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("abbreviate", TimeUnit.class);
@@ -311,6 +399,10 @@ class MVStoreFileQueueCoverageTest {
     assertThat(method.invoke(queue, TimeUnit.DAYS)).isEqualTo("d");
   }
 
+  /**
+   * chooseUnit() 메서드가 입력된 나노초 값에 따라 적절한 TimeUnit을 선택하는지 검증한다.
+   * <p>1일 이상이면 DAYS, 1시간 이상이면 HOURS 등 계층적으로 단위를 선택해야 한다.</p>
+   */
   @Test
   void testChooseUnit() throws Exception {
     java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("chooseUnit", long.class);
@@ -324,35 +416,47 @@ class MVStoreFileQueueCoverageTest {
     assertThat(method.invoke(queue, TimeUnit.NANOSECONDS.toNanos(1))).isEqualTo(TimeUnit.NANOSECONDS);
   }
 
+  /**
+   * abbreviate()의 default 분기에 도달하는 케이스를 위한 테스트 플레이스홀더이다.
+   * <p>
+   * 표준 Java TimeUnit은 모든 케이스가 switch 문으로 처리되므로 default 분기는
+   * 이론적으로 도달 불가능하다. JaCoCo 커버리지 제외 대상이다.
+   * </p>
+   */
   @Test
   void testAbbreviateDefault() throws Exception {
     java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("abbreviate", TimeUnit.class);
     method.setAccessible(true);
-    
-    // We need a TimeUnit that is not in the switch case. 
+
+    // We need a TimeUnit that is not in the switch case.
     // But switch covers all standard TimeUnits from NANOSECONDS to DAYS.
     // There are no other TimeUnits in standard Java unless it's a mock.
     // However, JaCoCo might mark the 'default: throw new AssertionError()' as missed.
   }
 
+  /**
+   * 존재하지 않는 경로로 fileName 필드를 변경한 후 fileSize() 메서드를 호출하면
+   * IOException이 처리되어 0이 반환되는지 검증한다.
+   * <p>Files.size()가 NoSuchFileException(IOException 하위 클래스)을 던지면 0을 반환해야 한다.</p>
+   */
   @Test
   void testFileSizeIOException() throws Exception {
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     MVStoreFileQueue<String> ioQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("io-test.db").toString());
-    
+
     // Changing fileName to something that exists but is not a file (like a directory)
     // might not trigger IOException in Files.size(), it might just return directory size.
     // Let's try to use a non-existent path that doesn't trigger InvalidPathException but triggers IOException.
-    
+
     java.lang.reflect.Field field = MVStoreFileQueue.class.getDeclaredField("fileName");
     field.setAccessible(true);
     field.set(ioQueue, tempDir.resolve("non-existent-sub/file.db").toString());
-    
+
     java.lang.reflect.Method method = MVStoreFileQueue.class.getDeclaredMethod("fileSize");
     method.setAccessible(true);
     // Files.size() throws NoSuchFileException if file doesn't exist, which is an IOException.
     assertThat(method.invoke(ioQueue)).isEqualTo(0L);
-    
+
     ioQueue.close();
   }
 }

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -158,6 +158,27 @@ class MVStoreFileQueueCoverageTest {
   }
 
   /**
+   * maxSize=2로 설정된 큐가 가득 찼을 때 에러 메시지가 ">=" 형식을 사용하는지 검증한다.
+   * <p>조건이 size >= maxSize 이므로 메시지도 ">=" 기호를 사용해야 한다.</p>
+   */
+  @Test
+  void testEnqueueFullQueueErrorMessage() {
+    MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
+    properties.setMaxSize(2);
+    MVStoreFileQueue<String> smallQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("msg-test.db").toString());
+
+    smallQueue.enqueue("one");
+    smallQueue.enqueue("two");
+
+    assertThatThrownBy(() -> smallQueue.enqueue("three"))
+      .isInstanceOf(FileQueueException.class)
+      .cause()
+      .hasMessageContaining("size 2 >= maxSize 2");
+
+    smallQueue.close();
+  }
+
+  /**
    * maxSize=2로 설정된 큐에 1개가 있을 때 2개짜리 리스트를 삽입하면 FileQueueException이 발생하는지 검증한다.
    * <p>size(1) + list.size(2) = 3 &ge; maxSize(2) 조건을 검증한다.</p>
    */
@@ -170,7 +191,9 @@ class MVStoreFileQueueCoverageTest {
     smallQueue.enqueue("one");
     List<String> list = Arrays.asList("two", "three");
     assertThatThrownBy(() -> smallQueue.enqueue(list))
-      .isInstanceOf(FileQueueException.class);
+      .isInstanceOf(FileQueueException.class)
+      .cause()
+      .hasMessageContaining("size 1 >= maxSize 2");
 
     smallQueue.close();
   }

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -324,32 +324,30 @@ class MVStoreFileQueueCoverageTest {
   }
 
   /**
-   * autoCommitDisabled=true이고 batchSize=1일 때 MVStore가 강제로 닫힌 상태에서
-   * enqueue를 시도하면 예외가 발생하는지 검증한다.
-   * <p>내부 commitIfNeeded() 호출 시 MVStore가 닫혀 있으면 예외가 발생해야 한다.</p>
+   * autoCommitDisabled=true이고 batchSize=1일 때 enqueue마다 doCommit()이 호출되어
+   * commit이 정상적으로 수행되는지 검증한다.
+   * <p>
+   * batchSize=1로 설정하면 매 enqueue마다 commit이 발생한다.
+   * close() 후 재오픈 시 데이터가 영속화되었는지 확인한다.
+   * </p>
    */
   @Test
-  void testCommitIfNeededException() throws Exception {
+  void testCommitIfNeededException() {
+    String dbPath = tempDir.resolve("commit-test.db").toString();
     MVStoreFileQueueProperties properties = new MVStoreFileQueueProperties();
     properties.setAutoCommitDisabled(true);
     properties.setBatchSize(1);
 
-    MVStoreFileQueue<String> mockQueue = new MVStoreFileQueue<>(properties, tempDir.resolve("mock-commit.db").toString());
+    MVStoreFileQueue<String> commitQueue = new MVStoreFileQueue<>(properties, dbPath);
+    assertThat(commitQueue.enqueue("committed-item")).isTrue();
+    assertThat(commitQueue.size()).isEqualTo(1);
+    commitQueue.close();
 
-    org.h2.mvstore.MVStore mvStore = (org.h2.mvstore.MVStore)
-        org.junit.platform.commons.util.ReflectionUtils.tryToReadFieldValue(MVStoreFileQueue.class, "mvStore", mockQueue).get();
-
-    mvStore.close(); // Force commit to fail because it's closed
-
-    // We can't easily make commit() throw an exception that is not caught or handled,
-    // but we can try to trigger the paths.
-    // In current implementation, mvStore.commit() is called.
-
-    try {
-        mockQueue.enqueue("test");
-    } catch (Exception e) {
-        // Expected
-    }
+    // doCommit()이 정상 동작했다면 재오픈 시 데이터가 있어야 한다
+    MVStoreFileQueue<String> reopened = new MVStoreFileQueue<>(properties, dbPath);
+    assertThat(reopened.size()).isEqualTo(1);
+    assertThat(reopened.dequeue()).isEqualTo("committed-item");
+    reopened.close();
   }
 
   /**

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
@@ -13,6 +13,10 @@ class MVStoreFileQueueUnitTest {
   @TempDir
   Path tempDir;
 
+  /**
+   * autoCommitDisabled=true 설정 시 큐가 정상적으로 초기화되는지 검증한다.
+   * <p>FileQueueFactory를 통해 큐 생성 시 예외가 발생하지 않아야 한다.</p>
+   */
   @DisplayName("set auto commit disabled")
   @Test
   void t0() {
@@ -27,6 +31,13 @@ class MVStoreFileQueueUnitTest {
       .isNull();
   }
 
+  /**
+   * maxSize=0 설정된 큐에 아이템을 삽입하면 FileQueueException이 발생하는지 검증한다.
+   * <p>
+   * 예외는 "[MVStoreFileQueue] Failed to acquire write lock after 3 attempts" 메시지를 가지며,
+   * 원인(cause)은 "[MVStoreFileQueue] Queue is full: 0 > 0" 메시지를 가져야 한다.
+   * </p>
+   */
   @DisplayName("throw Queue is full exception")
   @Test
   void t1() {
@@ -42,12 +53,16 @@ class MVStoreFileQueueUnitTest {
     // then
     assertThatCode(() -> fileQueue.enqueue("ITEM"))
       .isInstanceOfSatisfying(FileQueueException.class, e -> {
-        assertThat(e.getMessage()).isEqualTo("[MVStoreFileQueue] Failed to acquire write lock after 3 attempts");
+        assertThat(e.getMessage()).isEqualTo("[MVStoreFileQueue] Failed to execute with write lock after 3 attempts");
         assertThat(e.getCause()).isInstanceOf(FileQueueException.class);
         assertThat(e.getCause().getMessage()).isEqualTo("[MVStoreFileQueue] Queue is full: 0 > 0");
       });
   }
 
+  /**
+   * 빈 큐에서 dequeue() 호출 시 null을 반환하는지 검증한다.
+   * <p>아이템이 없는 큐에서 dequeue()는 예외 없이 null을 반환해야 한다.</p>
+   */
   @DisplayName("dequeue throw exception if empty")
   @Test
   void t2() {

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
@@ -55,7 +55,7 @@ class MVStoreFileQueueUnitTest {
       .isInstanceOfSatisfying(FileQueueException.class, e -> {
         assertThat(e.getMessage()).isEqualTo("[MVStoreFileQueue] Failed to execute with write lock after 3 attempts");
         assertThat(e.getCause()).isInstanceOf(FileQueueException.class);
-        assertThat(e.getCause().getMessage()).isEqualTo("[MVStoreFileQueue] Queue is full: 0 > 0");
+        assertThat(e.getCause().getMessage()).isEqualTo("[MVStoreFileQueue] Queue is full: size 0 >= maxSize 0");
       });
   }
 

--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueUnitTest.java
@@ -34,8 +34,8 @@ class MVStoreFileQueueUnitTest {
   /**
    * maxSize=0 설정된 큐에 아이템을 삽입하면 FileQueueException이 발생하는지 검증한다.
    * <p>
-   * 예외는 "[MVStoreFileQueue] Failed to acquire write lock after 3 attempts" 메시지를 가지며,
-   * 원인(cause)은 "[MVStoreFileQueue] Queue is full: 0 > 0" 메시지를 가져야 한다.
+   * FileQueueException은 비즈니스 예외이므로 재시도 없이 즉시 전파된다.
+   * 예외 메시지에 "Queue is full: size 0 >= maxSize 0"이 포함되어야 한다.
    * </p>
    */
   @DisplayName("throw Queue is full exception")
@@ -53,9 +53,8 @@ class MVStoreFileQueueUnitTest {
     // then
     assertThatCode(() -> fileQueue.enqueue("ITEM"))
       .isInstanceOfSatisfying(FileQueueException.class, e -> {
-        assertThat(e.getMessage()).isEqualTo("[MVStoreFileQueue] Failed to execute with write lock after 3 attempts");
-        assertThat(e.getCause()).isInstanceOf(FileQueueException.class);
-        assertThat(e.getCause().getMessage()).isEqualTo("[MVStoreFileQueue] Queue is full: size 0 >= maxSize 0");
+        assertThat(e.getMessage()).contains("Queue is full: size 0 >= maxSize 0");
+        assertThat(e.getCause()).isNull();
       });
   }
 


### PR DESCRIPTION
## Summary
- `acquireWriteLock/ReadLock` → `executeWithWriteLock/ReadLock` 메서드명 개선
- maxSize 초과 에러 메시지 수정 (`>` → `>=`)
- 비즈니스 예외(FileQueueException 등) 즉시 전파, 불필요한 재시도 제거
- `doCommit()` 예외 처리 추가 — commit 실패 시 큐 가용성 유지
- lock 내부 closed 체크 추가 — race condition 방어
- FileQueue 인터페이스 전체 Javadoc 추가
- 테스트 130개 이상 추가 (JaCoCo 90%+ branch coverage 유지)

## Motivation
코드 분석 결과 발견된 Critical/High 이슈 수정:
- 메서드명이 실제 동작(action 실행 재시도)을 표현하지 못함
- `>=` 조건인데 에러 메시지에 `>` 사용 → 사용자 혼동
- 큐 가득 참 예외가 3회 재시도 후 래핑되어 느리게 실패
- commit 실패 시 enqueue 결과 유실 가능성
- checkClosed()와 실제 작업 사이 race condition

## Changes
- `MVStoreFileQueue.java`: 메서드명 변경, 예외 처리 개선, doCommit() 추출, closed 방어 로직
- `FileQueue.java`: 모든 메서드 Javadoc 추가
- `MVStoreFileQueueAdditionalTest.java`: 신규 테스트 파일 (경계값, 동시성, 회귀)
- `MVStoreFileQueueCoverageTest.java`: 커버리지 테스트 대폭 보강
- `MVStoreFileQueueUnitTest.java`: 변경된 동작에 맞게 assertion 업데이트

## Test plan
- [x] `./gradlew build` 빌드 성공
- [x] 전체 테스트 통과
- [x] JaCoCo branch coverage 90%+ 달성