### PR TITLE
test(coverage): interruptor.join()으로 인터럽트 플래그 누수 수정

### DIFF
--- a/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
+++ b/src/test/java/io/github/ppzxc/fq/MVStoreFileQueueCoverageTest.java
@@ -77,6 +77,7 @@ class MVStoreFileQueueCoverageTest {
         // Expected
     } finally {
         lock.writeLock().unlock();
+        interruptor.join(); // Wait for interruptor to deliver interrupt before clearing
         Thread.interrupted(); // Clear interrupted status
     }
 


### PR DESCRIPTION
## Summary
- `testSleepBackoffInterrupted()`의 타이밍 레이스로 인한 인터럽트 플래그 누수 수정

## Motivation
`MVStoreFileQueueFullTest.shouldHandleConcurrentEnqueueAndDequeue()`가 CI에서 간헐적으로 `InterruptedException`으로 실패.

**근본 원인**: `MVStoreFileQueueCoverageTest.testSleepBackoffInterrupted()`에서 타이밍 레이스 발생:
1. `interruptor` 스레드가 200ms sleep 후 메인 스레드를 interrupt 예정
2. `enqueue()`가 락 경합으로 즉시 `FileQueueException` throw
3. `finally`에서 `Thread.interrupted()`가 인터럽트 도착 전에 실행 → 플래그 클리어 안 됨
4. `interruptor`가 뒤늦게 `mainThread.interrupt()` 호출 → 플래그가 set된 채로 잔류
5. JUnit이 같은 스레드를 재사용해 `FullTest`를 실행하면 `dequeueLatch.await()`가 즉시 `InterruptedException` throw

## Changes
- `MVStoreFileQueueCoverageTest.java`: `finally` 블록에 `interruptor.join()` 추가
  - `Thread.interrupted()` 호출 전에 `interruptor` 완료를 보장
  - 인터럽트가 반드시 도착한 뒤 플래그를 클리어하여 누수 방지

## Test plan
- [ ] `./gradlew test --tests MVStoreFileQueueCoverageTest.testSleepBackoffInterrupted`
- [ ] `./gradlew test --tests MVStoreFileQueueFullTest.shouldHandleConcurrentEnqueueAndDequeue`
- [ ] `./gradlew test`